### PR TITLE
Implement tag delete for docker hub

### DIFF
--- a/registry/tags.go
+++ b/registry/tags.go
@@ -1,5 +1,10 @@
 package registry
 
+import (
+	"fmt"
+	"net/http"
+)
+
 type tagsResponse struct {
 	Tags []string `json:"tags"`
 }
@@ -22,4 +27,24 @@ func (registry *Registry) Tags(repository string) (tags []string, err error) {
 			return nil, err
 		}
 	}
+}
+
+// DeleteTag is Hub specific to delete a tag from the docker registry.
+func (registry *Registry) DeleteTag(repository, tag string) (err error) {
+	url := fmt.Sprintf("https://hub.docker.com/v2/repositories/%s/tags/%s/", repository, tag)
+
+	registry.Logf("registry.tag.delete url=%s repository=%s tag=%s", url, repository, tag)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := registry.Client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This doesn't currently work, but I'm opening this for purposes of discussion.  I realized today from docker/hub-feedback#1759 that the API for hub is generally broken in a number of ways.

I've added a method to delete tags that are on the hub, but its not sending the correct authentication.  Feedback would be greatly appreciated.